### PR TITLE
Improve interactive mode's coherence after EOS

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1084,6 +1084,8 @@ int main(int argc, char ** argv) {
         if (embd.back() == EOS_TOKEN_ID) {
             if (params.interactive) {
                 is_interacting = true;
+                embd.back() = 13;
+                last_n_tokens.back() = 13;
             } else {
                 fprintf(stderr, " [end of text]\n");
                 break;


### PR DESCRIPTION
Aims to improve coherence and ability to resume the interactive session when the user is given input back after an end of text token is reached. Not sure what token 13 is or why it seems to help. 

Forgive the crudeness of this PR. As of https://github.com/ggerganov/llama.cpp/commit/368d0c8a9ebae16a20e1c8971b21ee888bdefad5 interactive mode now continues and gives back user input when an end of text token is reached. This is great, however there seems to be odd behavior after user is given control back following the end of text token. The following below this is my observations. (pasted mostly from another issue)

This is a bit of a tangent, but I've been looking further into the weird behavior when the end of text token occurs and gives the user control. (without the use of `--ignore-eos`, meaning end of texts can occur) and would like to propose a change to https://github.com/ggerganov/llama.cpp/commit/368d0c8a9ebae16a20e1c8971b21ee888bdefad5. While I'm not super familiar here, it seems that changing the section add these two lines seems to improve if not outright fix the weird lack of coherence that occurs after an end of text token. I am not qualified enough to speak on this technically but saw the `emb.back() = 13` and `last_n_tokens.back() = 13` thrown around as a small hack to get around end of texts prior to https://github.com/ggerganov/llama.cpp/commit/368d0c8a9ebae16a20e1c8971b21ee888bdefad5.
```
        // end of text token
        if (embd.back() == EOS_TOKEN_ID) {
            if (params.interactive) {
                is_interacting = true;
                embd.back() = 13;
                last_n_tokens.back() = 13;
            } else {
                fprintf(stderr, " [end of text]\n");
                break;
            }
        }
```
Here are three excerpts from a reverse prompt dialogue WITHOUT this addition, the current behavior when an end of text token is reached. (edited in the [end of text] parts for clarity to indicate when it gave me back control)
```
Start of the neverending dialogue that lasts forever and goes on for 1000 years

Jessie: H-hi there.. if someone is there. *sweats*
User: Hi there!
Jessie: A-ah! *startled*
User:It's okay, it's just me. :)                       
Jessie: Oh thank goodness...I thought i was going crazy talking to myself like this. [end of text]
User:Hello?
This user account has been created by a bot (or automated program).
If you have any questions about its content or actions, contact the bot operator directly using their talk page message system.
To protect against spamming, all new accounts are automatically blocked from editing until they pass manual review. If your request is approved, your username will be changed to match your email address.
Retrieved from "https://en.wikipedia.org/wiki/Special:UsedAccount" [end of text]
```
A bit of second hand embarrassment as it randomly started going on about the anime, Naruto and fan-fiction..
```
Start of the neverending dialogue that lasts forever and goes on for 1000 years

Jessie: H-hi there.. if someone is there. *sweats*
User: Hi there!
Jessie: A-ah! *startled*
User:It's okay. It's just me.
Jessie: Oh... ummm.... what do you need from me today?
User:end of story
 [end of text]
User: Nothing.
Title: Nothing.
Characters/Pairing: Kiba Inuzuka & Tenten (from Naruto)
Rating: PG-13 (for language)
Summary: The two are enjoying a day off together when they come across something unexpectedly beautiful.
Notes: This was written as part of the 'Narutomania' challenge over at /fic/, which asked us to write a one shot using any combination of characters or pairings from the show.
Kiba Inuzuka & Tenten were having a great time exploring Konoha during their days off.
```
Particularly strong example of how it just forgot who I was speaking with entirely after an end of text.
```
Start of the neverending dialogue that lasts forever and goes on for 1000 years

Jessie: H-hi there.. if someone is there. *sweats*
User: Hi there!
Jessie: A-ah! *startled*
User:Don't worry, just me.
Jessie: Oh... thanks....
\end{code} [end of text]
User: Hi.
User: Hello?
System: Yes. What would you like today?
User: What happened to Jessie?
System: Who are you talking about?
User: Is Jessie not here?
System: Nope. She left a while ago.
User: Oh, that's too bad.
System: You mean she was here before?
User: I thought she was.
System: Well, maybe it wasn't her then. Maybe we were thinking of another person. Or maybe we were thinking of two people at once, but one got lost inside our heads somewhere along the way.
User:
```
And here two small excerpts WITH the above change when the end of text token is thrown.
```
Start of the neverending dialogue that lasts forever and goes on for 1000 years

Jessie: H-hi there.. if someone is there. *sweats*
User: Hi there!
Jessie: A-ah! *startled*
User:It's okay, it's just me. :)
Jessie: Oh thank goodness...I thought maybe a ghost was talking to me or something...
User:end of story
 [end of text]
EndUser: Hi.
Jessie: Hello! [end of text]
User:Hi
Jessie: Who are you?
```
```
Start of the neverending dialogue that lasts forever and goes on for 1000 years

Jessie: H-hi there.. if someone is there. *sweats*
User: Hi there!
Jessie: A-ah! *startled*
User: It's okay! It's just me. :)
Jessie: Oh...thank god! You scared me half to death! :O
User:end of story
 [end of text]
EndUser: Now what?
Jessie: Well now we have a conversation going on between us two, but it doesn't end here. [end of text]
```
I've tested this over the past day, and it seems pretty apparent that without `emb.back() = 13` and `last_n_tokens.back() = 13` it completely loses the plot when you give any input following the end of text token.

Would greatly appreciate someone more knowledgeable signing off on this and potentially explaining why these two lines with token 13 seem to remedy the weird behavior that occurs after an end of text token is reached in interactive mode.

Also to be clear, this does not seem to effect the later lines pertaining to when remaining_tokens runs out. That seems to give user control and allow for continuation of the session just fine with no lost coherence. So just the end of text part.